### PR TITLE
Conjugate and not swap...

### DIFF
--- a/pyinn/cdgmm.py
+++ b/pyinn/cdgmm.py
@@ -17,7 +17,8 @@ __global__ void swap(float2 *x, int total)
       return;
 
    float2 v = x[tx];
-   x[tx] = make_float2(v.y, v.x);
+   //x[tx] = make_float2(v.y, v.x);
+   x[tx] = make_float2(v.x, -v.y);
 }
 """
 
@@ -103,8 +104,11 @@ class CDGMM(Function):
         input, x = self.saved_tensors
         grad_input = grad_x = None
         if self.needs_input_grad[0]:
+            grad_output = grad_output.contiguous()
+            swap(x)
             grad_input = cublas_cdgmm(grad_output.contiguous(), x)
-            swap(grad_input)
+            swap(x)
+            
             assert grad_input.size() == input.size()
         if self.needs_input_grad[1]:
             raise NotImplementedError


### PR DESCRIPTION
The bug was the following, it is required to conjugate "x". I used your kernel and did "two" conjugates on "x" (so that there is no effect for future call of the routine), I guess it can be optimized. Now everything works well