### PR TITLE
Summation of gradient weights by default do not require keepdim=false.

### DIFF
--- a/pyinn/conv2d_depthwise.py
+++ b/pyinn/conv2d_depthwise.py
@@ -191,7 +191,7 @@ class Conv2dDepthwise(Function):
                   grid=(GET_BLOCKS(n),1,1),
                   args=[grad_output.data_ptr(), input.data_ptr(), weight_buffer.data_ptr()],
                   stream=Stream(ptr=torch.cuda.current_stream().cuda_stream))
-                grad_weight = weight_buffer.view(weight.size() + (-1,)).sum(-1, keepdim=False)
+                grad_weight = weight_buffer.view(weight.size() + (-1,)).sum(-1)
 
         return grad_input, grad_weight
 


### PR DESCRIPTION
Older versions of PyTorch do not have `keepdim=False` available, and on newer PyTorch versions, keepdim is false by default.